### PR TITLE
Use jQuery methods instead comparing the string

### DIFF
--- a/app/views/places/show.html.erb
+++ b/app/views/places/show.html.erb
@@ -129,16 +129,18 @@
 <!--button jquery -->
 	<script>
 		$('#showComments').click(function(){
-        var $icon = $(this).find('.glyphicon');
-        if($icon.hasClass('glyphicon-collapse-down')) {
-          $icon.addClass('glyphicon-collapse-up');
-          $icon.removeClass('glyphicon-collapse-down');
-		      $(this).find('.text').text('Hide Comments');
-        } else {
-          $icon.removeClass('glyphicon-collapse-up');
-          $icon.addClass('glyphicon-collapse-down');
-		      $(this).find('.text').text('Show Comments');
-		    }
+        // Could have made an $icon_span, but we only use it once this way
+        $(this).
+          find('.glyphicon').
+          toggleClass('glyphicon-collapse-down glyphicon-collapse-up');
+
+        $text_span = $(this).find('.text');
+
+        if ($text_span.text() === 'Show Comments') {
+          $text_span.text('Hide Comments');
+        } else if ($text_span.text() === 'Hide Comments') {
+          $text_span.text('Show Comments');
+        }
 		});
 	</script>
 <hr />

--- a/app/views/places/show.html.erb
+++ b/app/views/places/show.html.erb
@@ -121,16 +121,23 @@
 			<br /><br />
 		</div>
 		<div class="text-center">
-		<a class="btn btn-warning" data-toggle="collapse" data-target="#showcomments" id="showComments"><span class="glyphicon glyphicon-collapse-down"></span> Show Comments</a>
+      <a class="btn btn-warning" data-toggle="collapse" data-target="#showcomments" id="showComments">
+        <span class="glyphicon glyphicon-collapse-down"></span>
+        <span class="text">Show Comments</span>
+      </a>
 	</div>
 <!--button jquery -->
 	<script>
 		$('#showComments').click(function(){
-		    console.log($(this).text());
-		    if($(this).html().trim() == '<span class="glyphicon glyphicon-collapse-down"></span> Show Comments'){
-		        $(this).html('<span class="glyphicon glyphicon-collapse-up"></span> Hide Comments');
-		    }else{
-		         $(this).html('<span class="glyphicon glyphicon-collapse-down"></span> Show Comments');
+        var $icon = $(this).find('.glyphicon');
+        if($icon.hasClass('glyphicon-collapse-down')) {
+          $icon.addClass('glyphicon-collapse-up');
+          $icon.removeClass('glyphicon-collapse-down');
+		      $(this).find('.text').text('Hide Comments');
+        } else {
+          $icon.removeClass('glyphicon-collapse-up');
+          $icon.addClass('glyphicon-collapse-down');
+		      $(this).find('.text').text('Show Comments');
 		    }
 		});
 	</script>


### PR DESCRIPTION
The issue was I thought `$(this)` would refer to the span with the glyphicon. I avoided that by making a `$icon` variable to use instead.
I also added a span with a class for the text, since setting the text on `$(this)` wiped out the glyphicon span.

I'm going to make another commit to this, to simplify the code even more. I just wanted to present it in two steps, in the interest of clarity.
